### PR TITLE
Change index.py file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,10 @@ Here is a template for new release sections
 - the selected state cannot be clicked or selected again (#109)
 - sidebar panels are defined via a template sidebar_checkbox.html (#115)
 - the side panel checkboxes are now grey out when not used (#128)
+
 - the grid and populated buttons appear now as the same button to the user (#136)
+- index.py is now at the root of the repository (#142)
+
 ### Removed
 - redundant accordion menu (#10)
 - redundant onclick function for nigeria_states_geojson layer (#108)

--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ pip3 install -r app/requirements.txt
 
 Start the app with  
 ```
-python3 app/index.py
+python3 index.py
 ```

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,7 +1,7 @@
 import os
 
 from flask import Flask, render_template, request, jsonify, url_for, redirect, Response
-from utils import assign_visibility
+from .utils import define_function_jinja
 
 def create_app(test_config=None):
     # create and configure the app
@@ -54,5 +54,5 @@ def create_app(test_config=None):
             headers={"Content-disposition": "attachment; filename={}.csv".format(args["state"])}
         )
 
-    app.jinja_env.globals.update(assign_visibility=assign_visibility)
+    define_function_jinja(app)
     return app

--- a/app/index.py
+++ b/app/index.py
@@ -1,6 +1,0 @@
-from __init__ import create_app
-
-app = create_app()
-
-if __name__ == '__main__':
-    app.run(debug=True)

--- a/app/utils.py
+++ b/app/utils.py
@@ -13,4 +13,5 @@ def assign_visibility(visible_levels):
     return visibility
 
 
-print(assign_visibility(()))
+def define_function_jinja(app):
+    app.jinja_env.globals.update(assign_visibility=assign_visibility)

--- a/index.py
+++ b/index.py
@@ -1,0 +1,6 @@
+from app import create_app
+
+app = create_app()
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
Now instead of `python app/index.py` we can just do `python index.py` (this also helps the app not to fail due to import errors on heroku)