### PR TITLE
style state name on bottom left of the map

### DIFF
--- a/app/static/css/maps.css
+++ b/app/static/css/maps.css
@@ -1,4 +1,27 @@
 /* custom CSS */
+.leaflet-bottom.leaflet-left .leaflet-control {
+  padding-left: 0;
+  margin-left: 1rem;
+  background-color: #eeeff1;
+}
+
+.leaflet-bottom.leaflet-left .leaflet-control h4 {
+  padding-left: .5rem;
+  padding-right: .5rem;
+  padding-top: .5rem;
+  text-align: center;
+}
+
+.leaflet-bottom.leaflet-left .selection_detail {
+  padding-left: 0;
+  margin-left: 0;
+  margin-bottom: 0;
+}
+
+.leaflet-bottom.leaflet-left {
+  
+}
+
 .map-legend {
   padding: 1rem 1rem;
 }


### PR DESCRIPTION
Fix #185 
Added light background color to state name so that it is always readable on all kinds of backgrounds