### PR TITLE
change distance beween blitz logo and text to fit website

### DIFF
--- a/app/static/css/maps.css
+++ b/app/static/css/maps.css
@@ -560,6 +560,11 @@ p.sidebar-panel-item-title {
     height: 3.25rem;
     transform: translateY(0px);
     padding-left: .75rem;
+    margin-right: 1rem;
+}
+
+#header-maps-blitz-div h2{
+  padding-left: 0;
 }
 
 #header-maps-logo-nigeria{


### PR DESCRIPTION
@Bachibouzouk I just changed the distance between the logo image and text, because the font-family and size should be the same on the map and website, but please double-check