### PR TITLE
Implement feedback

### DIFF
--- a/app/static/css/maps.css
+++ b/app/static/css/maps.css
@@ -122,6 +122,10 @@ a {
   height: 1.5rem;
   vertical-align: middle;
 }
+.map-legend__label p {
+    text-align: left;
+}
+
 
 .legend-color {
   height: .5rem;
@@ -227,7 +231,7 @@ body {
 
 
 .map-legend-grid {
-    padding-left: 5rem;
+    padding-left: 3rem;
 }
 
 .split {

--- a/app/static/css/maps.css
+++ b/app/static/css/maps.css
@@ -731,6 +731,7 @@ img.footer-maps-logos__giz {
 
 .info-box .info-box__icon {
   padding: .5rem;
+  text-align: left;
 }
 
 .browse-box {

--- a/app/static/css/maps.css
+++ b/app/static/css/maps.css
@@ -317,6 +317,7 @@ background-color: #fff;
   width: 100%;
   font-size: 10pt;
   font-weight: bold;
+  font-family: 'Source Sans Pro', sans-serif;
   padding: .75rem .5rem;
   border-radius: 4px;
   cursor: pointer;
@@ -389,6 +390,7 @@ button {
   color: #464646;
   font-size: 10pt;
   font-weight: bold;
+  font-family: 'Source Sans Pro', sans-serif;
 }
 
 .select-items {

--- a/app/static/css/maps.css
+++ b/app/static/css/maps.css
@@ -244,7 +244,7 @@ body {
 	//margin: 20px auto;
 }
 .sp-circle {
-	border: 4px #fff solid;
+	border: 4px #eeeff1 solid;
 	border-top: 4px rgb(70,70,70) solid;
 	border-radius: 50%;
 	-webkit-animation: spCircRot .6s infinite linear;
@@ -792,7 +792,7 @@ img.footer-maps-logos__giz {
   padding-left: 0.5rem;
   padding-right: 0.5rem;
   font-weight: 700;
-  transform: translateY(8px);
+  text-align: center;
 }
 
 .browse-box .browse-box__btn a {
@@ -801,6 +801,22 @@ img.footer-maps-logos__giz {
   display: flex;
   justify-content: center;
   align-items: center;
+  height: 40px;
+}
+
+.browse-box__number {
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+}
+
+.browse-box__clusters {
+  display: inline;
+  vertical-align: middle;
+}
+
+#browse-spin {
+    padding-left:0.5rem;
 }
 
 .browse-box .browse-box__btn img {

--- a/app/static/css/maps.css
+++ b/app/static/css/maps.css
@@ -42,6 +42,14 @@ h1, h2, h3 {
 }
 
 @font-face {
+  font-family: 'Source Sans Pro';
+  src: url('../fonts/SourceSansPro-Bold-Italic.woff2') format('woff2'),
+    url('../fonts/Poppins-Bold-Italic.woff') format('woff');
+  font-weight: bold;
+  font-style: italic;
+}
+
+@font-face {
   font-family: 'Poppins';
   src: url('../fonts/Poppins-Bold.woff2') format('woff2'),
       url('../fonts/Poppins-Bold.woff') format('woff');

--- a/app/static/css/maps.css
+++ b/app/static/css/maps.css
@@ -236,6 +236,30 @@ body {
   }
 }
 
+/* Spinner Circle Rotation */
+.sp {
+	width: 25px;
+	height: 25px;
+	//clear: both;
+	//margin: 20px auto;
+}
+.sp-circle {
+	border: 4px #fff solid;
+	border-top: 4px rgb(70,70,70) solid;
+	border-radius: 50%;
+	-webkit-animation: spCircRot .6s infinite linear;
+	animation: spCircRot .6s infinite linear;
+}
+@-webkit-keyframes spCircRot {
+	from { -webkit-transform: rotate(0deg); }
+	to { -webkit-transform: rotate(359deg); }
+}
+@keyframes spCircRot {
+	from { transform: rotate(0deg); }
+	to { transform: rotate(359deg); }
+}
+
+
 
 
 .map-legend-grid {

--- a/app/static/js/map.js
+++ b/app/static/js/map.js
@@ -35,7 +35,7 @@ gridLegend.update = function(props) {
 
 var baseMaps = {
   "Humanitarian OSM": hot,
-  "esri": esri,
+  "Esri World Imagery": esri,
 };
 
 function remove_basemaps() {

--- a/app/static/js/map.js
+++ b/app/static/js/map.js
@@ -12,7 +12,7 @@ legend.onAdd = function(map) {
   return this._div;
 };
 legend.update = function(props) {
-  this._div.innerHTML = '<div class="grid-x"><div class="small-3 map-legend__text legend_text"><div class="legend-color legend-color--green"></div></div><div class="small-9 map-legend__label"><p>Datasets available</p></div><div class="small-3 map-legend__text legend_text"><div class="legend-color legend-color--gray"></div></div><div class="small-9 map-legend__label"><p>Datasets <span class="map-legend--highlight">not yet</span> available</p></div></div>'
+  this._div.innerHTML = '<div class="grid-x"><div class="small-3 map-legend__text"><div class="legend-color-grid legend-color--green"></div></div><div class="small-9 map-legend__label"><p>Datasets available</p></div><div class="small-3 map-legend__text"><div class="legend-color-grid legend-color--gray"></div></div><div class="small-9 map-legend__label"><p>Datasets <span class="map-legend--highlight">not yet</span> available</p></div></div>'
 };
 legend.addTo(map);
 
@@ -30,8 +30,8 @@ gridLegend.onAdd = function(map) {
 };
 
 gridLegend.update = function(props) {
-  this._div.innerHTML = '<div class="grid-x"><div class="small-3 map-legend__text"><div class="legend-color-grid legend-color--brown"></div></div><div class="small-9 legend-text">11kV Grid</div><div class="small-3 map-legend__text"><div class="legend-color legend-color-grid legend-color--red"></div></div><div class="small-9 legend-text">33kV Grid</div></div>'
-};
+  this._div.innerHTML = '<div class="grid-x"><div class="small-3 map-legend__text"><div class="legend-color-grid legend-color--brown"></div></div><div class="small-9 map-legend__label">11 kV Grid</div><div class="small-3 map-legend__text"><div class="legend-color legend-color-grid legend-color--red"></div></div><div class="small-9 map-legend__label">33 kV Grid</div></div>'
+  };
 
 var baseMaps = {
   "Humanitarian OSM": hot,
@@ -157,7 +157,6 @@ function update_clusterInfo(properties, selectedClustersNum=0, clusterNum="?") {
     if (properties == "all"){
         control_content =
           '<div class="grid-x browse-box__items">\
-            <div class="browse-box--left">ID:</div><div class="browse-box--right"></div>\
             <div class="browse-box--left">Area (km²):</div><div class="browse-box--right"></div>\
             <div class="browse-box--left">Distance to Grid (km):</div><div class="browse-box--right"></div>\
           </div>';
@@ -167,7 +166,6 @@ function update_clusterInfo(properties, selectedClustersNum=0, clusterNum="?") {
         // all
         control_content =
           '<div class="grid-x browse-box__items">\
-            <div class="browse-box--left">ID:</div><div class="browse-box--right">' + properties.cluster_all_id + '</div>\
             <div class="browse-box--left">Area (km²):</div><div class="browse-box--right">' + parseFloat(properties.area_km2).toFixed(2) + '</div>\
             <div class="browse-box--left">Distance to Grid (km):</div><div class="browse-box--right">' + parseFloat(properties.grid_dist_km).toFixed(1) + '</div>\
           </div>';

--- a/app/static/js/map.js
+++ b/app/static/js/map.js
@@ -152,7 +152,7 @@ function update_clusterInfo(properties, selectedClustersNum=0, clusterNum="?") {
 
     var control_content = ''
 
-    var settlements_content = '<span>Click on a settlement</span>'
+    var settlements_content = '<div class="browse-box__clusters"><div><span>Click on a settlement</span></div></div>'
 
     if (properties == "all"){
         control_content =
@@ -169,7 +169,7 @@ function update_clusterInfo(properties, selectedClustersNum=0, clusterNum="?") {
             <div class="browse-box--left">Area (km²):</div><div class="browse-box--right">' + parseFloat(properties.area_km2).toFixed(2) + '</div>\
             <div class="browse-box--left">Distance to Grid (km):</div><div class="browse-box--right">' + parseFloat(properties.grid_dist_km).toFixed(1) + '</div>\
           </div>';
-          settlements_content = '<span>' + clusterNum + ' </span> of <span id="filtered-clusters-num">' + selectedClustersNum + '</span>'
+          settlements_content = '<div class="browse-box__clusters"><div><span>' + clusterNum + ' </span> of <span id="filtered-clusters-num">' + selectedClustersNum + '</span></div></div>'
     };
 
     if (properties == "og"){
@@ -191,8 +191,13 @@ function update_clusterInfo(properties, selectedClustersNum=0, clusterNum="?") {
           <div class="browse-box--left">Built-up density (%):</div><div class="browse-box--right">' +parseFloat(properties.percentage_building_area).toFixed(2) + '</div>\
           <div class="browse-box--left">Distance to Grid (km):</div><div class="browse-box--right">' + parseFloat(properties.grid_dist_km).toFixed(1) + '</div>\
         </div>';
-        settlements_content = '<span>' + clusterNum + ' </span> of <span id="filtered-clusters-num">' + selectedClustersNum + '</span>'
+        settlements_content = '<div class="browse-box__clusters"><div><span>' + clusterNum + ' </span> of <span id="filtered-clusters-num">' + selectedClustersNum + '</span></div></div>'
 
+    };
+
+    // display a loading wheel when the
+    if(is_currently_loading_clusters() == true){
+        settlements_content = '<div>Updating</div> <div id="browse-spin" class="sp sp-circle"></div>';
     };
 
     control_content = '\
@@ -203,9 +208,9 @@ function update_clusterInfo(properties, selectedClustersNum=0, clusterNum="?") {
             <a class="cell large-offset-1 large-2 btn--left" onclick="prev_selection_fun()">\
               <img class="state_info__img" src="../static/img/icons/i_arrow_left_g.svg">\
             </a>\
-            <p class="cell large-6 browse-box__number">'
+            <div class="cell large-6 browse-box__number">'
              + settlements_content +
-            '</p>\
+            '</div>\
             <a class="cell large-2 btn--right" onclick="next_selection_fun()">\
               <img class="state_info__img" src="../static/img/icons/i_arrow_right_g.svg">\
             </a>\

--- a/app/static/js/sidebar.js
+++ b/app/static/js/sidebar.js
@@ -415,6 +415,18 @@ function show_sidebar__btn(className) {
 };
 
 
+function show_loading_cluster(){
+    console.log("#" + get_cluster_type() + "-spin")
+    spinId = $("#" + get_cluster_type() + "-spin")[0];
+    console.log(spinId)
+    spinId.className = show_sidebar__btn(spinId.className);
+}
+
+function hide_loading_cluster(){
+    spinId = $("#" + get_cluster_type() + "-spin")[0];
+    spinId.className = hide_sidebar__btn(spinId.className);
+}
+
 function disable_sidebar_filter(className) {
   return className.replace(" active-filter", " hidden-filter");
 };

--- a/app/static/js/sidebar.js
+++ b/app/static/js/sidebar.js
@@ -308,7 +308,7 @@ function changeogBuildingsFootprintSlider(str, h, values) {
 var ogBuildingsFootprintSlider = document.getElementById('ogBuildingsFootprintSlider');
 noUiSlider.create(ogBuildingsFootprintSlider, {
   ...sliderOptions,
-  tooltips: [wNumb({suffix: ' %',}), wNumb({suffix: ' %',})],
+  tooltips: [wNumb({decimals: 2, suffix: ' %'}), wNumb({decimals: 2, suffix: ' %'})],
   start: [0, 0.8],
   range: {
     'min': [0, 0.01],

--- a/app/static/js/sidebar.js
+++ b/app/static/js/sidebar.js
@@ -26,6 +26,7 @@ var centroids_layer_ids = {};
 var current_cluster_centroids = Object();
 var currently_featured_centroid_id = 0;
 var flying_to_next_cluster = false;
+var downloadingClusters = false;
 var statesWithOgClusters = [
     'Jigawa',
      'Kano',
@@ -342,9 +343,11 @@ function update_filter(msg) {
         if (num_filtered_clusters == 1){
             new_text = "= " + num_filtered_clusters + " settlement";
         };
-        filter_title.text(new_text);
-        filter_title = $("#filtered-clusters-num");
-        filter_title.text(num_filtered_clusters);
+        if (downloadingClusters == false){
+            filter_title.text(new_text);
+            filter_title = $("#filtered-clusters-num");
+            filter_title.text(num_filtered_clusters);
+        };
     }
     return num_filtered_clusters;
 };
@@ -1015,13 +1018,24 @@ function convert_light_json_to_geojson(data, cluster_type) {
 // Function takes the data from update_centroids_data. Due to the asynchronous call they cannot simply be stored in a variable
 function update_centroids(msg){
   console.log("update centroid: " + msg);
-  // only fetch the data if it does not exist yet
   var cluster_type = get_cluster_type();
+  if (get_cluster_type() == "og"){
+    var filter_title = $("#n_ogclusters");
+  }
+  else{
+      var filter_title = $("#n_clusters");
+  }
+  var new_text = "= ... loading clusters info ...";
+  filter_title.text(new_text);
+
   if (centroids_layer_ids[selectedState] === undefined) {
     centroids_layer_ids[selectedState] = {};
   }
-
+  // only fetch the data if it does not exist yet
   if (centroids_layer_ids[selectedState][cluster_type] === undefined){
+        // to prevent filter to update while downloading
+        downloadingClusters = true;
+        show_loading_cluster();
         update_centroids_data(function(data, centroids_file_key, cluster_type){
             var centroids = convert_light_json_to_geojson(data, cluster_type)
             // Creates a geojson-layer with the data
@@ -1044,6 +1058,9 @@ function update_centroids(msg){
             centroids_layer_id = centroidsGroup.getLayerId(centroids_layer)
             // store this id in a dict with state name as keys
             centroids_layer_ids[centroids_file_key][cluster_type] = centroids_layer_id
+            // reset the download flag to false
+            downloadingClusters = false;
+            hide_loading_cluster();
             //update the filters
             update_filter()
         });

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -125,8 +125,11 @@
         <div class="grid-x">
           <div class="cell n_hide s_show v_show">
             <div class="sidebar-panel sidebar-panel-content content-filter hidden-filter sidebar-panel-filter-label" name="clustersContent">
-              <div class="sidebar-panel-item sidebar-panel-item-filter">
-                <p href="#" class="sidebar-panel-item-title sidebar-panel-item-title-filter">FILTERS <span id="n_clusters"><span></p>
+              <div class="sidebar-panel-item sidebar-panel-item-filter grid-x">
+                <div href="#" class="cell small-10 sidebar-panel-item-title sidebar-panel-item-title-filter">FILTERS <span id="n_clusters"></span></div>
+                <div class="cell small-2">
+                  <div id="all-spin" class="sp sp-circle is-hidden"></div>
+                </div>
               </div>
             </div>
           </div>
@@ -175,8 +178,11 @@
         <div class="grid-x">
           <div class="cell n_hide s_show v_show">
             <div class="sidebar-panel sidebar-panel-content content-filter hidden-filter sidebar-panel-filter-label" name="ogClustersContent">
-              <div class="sidebar-panel-item sidebar-panel-item-filter">
-                <p href="#" class="sidebar-panel-item-title sidebar-panel-item-title-filter">FILTERS <span id="n_ogclusters"><span></p>
+              <div class="sidebar-panel-item sidebar-panel-item-filter grid-x">
+                <div href="#" class="cell small-10 sidebar-panel-item-title sidebar-panel-item-title-filter">FILTERS <span id="n_ogclusters"></span></div>
+                <div class="cell small-2">
+                  <div id="og-spin" class="sp sp-circle is-hidden"></div>
+                </div>
               </div>
             </div>
           </div>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -14,9 +14,6 @@
 <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.3.0/dist/MarkerCluster.css" integrity="sha384-lPzjPsFQL6te2x+VxmV6q1DpRxpRk0tmnl2cpwAO5y04ESyc752tnEWPKDfl1olr" crossorigin="" />
 <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.3.0/dist/MarkerCluster.Default.css" integrity="sha384-5kMSQJ6S4Qj5i09mtMNrWpSi8iXw230pKU76xTmrpezGnNJQzj0NzXjQLLg+jE7k" crossorigin="" />
 
-<!-- Source Sans font -->
-<link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:700i&display=swap" rel="stylesheet">
-
 <!-- Compressed CSS -->
 <link rel="stylesheet" href="{{ url_for('static', filename='css/maps.css') }}" />
 <link rel="stylesheet" href="{{ url_for('static', filename='css/foundation.min.css') }}" />

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -253,7 +253,7 @@
 
       <div id="footer-maps" class="grid-x">
         <div class="cell footer-maps__text">
-          <p>Provided with the financial support of</p>
+          <p>Provided with the financial support of:</p>
         </div>
         <div id="footer-maps-logos-eu-ger" class="cell">
           <a href="https://europa.eu/european-union/index_en" target="_blank" rel="noreferrer">

--- a/app/templates/sidebar_checkbox.html
+++ b/app/templates/sidebar_checkbox.html
@@ -18,7 +18,7 @@
           {% endif %}
           <div class="cell small-2">
             <div class="sidebar-panel-item-button">
-              <input class="switch-input" id="{{ id }}Checkbox" type="checkbox" onclick="{{ id }}_cb_fun()" value="false">
+              <input class="switch-input" id="{{ id }}Checkbox" type="checkbox" onclick="{{ id }}_cb_fun(trigger='user')" value="false">
               <label class="switch-paddle" for="{{ id }}Checkbox">
               </label>
             </div>


### PR DESCRIPTION
# UX
- [x] You can replicate the issue with the following steps:
    From the national level click on a state with both cluster sets available
    Click on one of the “Remotely mapped settlements”
    Toggle the left or right arrows a few times to fly between the settlements
    Then select from the sidebar the “Identified settlements by satellite imagery”
    Then click the left or right button in the “browse the settlements” box
    It seems the settlements dont update to reflect the fact you are now on “Identified settlements by
    imagery” . The box and data is for the other cluster layer (Remotely mapped settlements).
# Design
- [x] Fix zeros in Building densities
- [x] Align tick and cross left
- [x] Fix font
- [x] Remove ID prop on ISSI clusters
- [x] Harmonize legends
- [x] Change esri
- [x] Add colon to financial support 
- [ ] Grey Village level button on national overview (use `disable_sidebar__btn` and `enable_sidebar__btn`)
- [ ] Make Capitalization consistent accross the webmap
- [ ] fix cluster boarders and color
- [ ] Fix filter scale