### PR TITLE
Update cluster toggle and filter selection when changing levels or states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,11 @@ Here is a template for new release sections
 - Centroid latitude and longitude information in csv file download (#299)
 
 ### Changed
-
+- Cluster toggles in sidebar automatically switch on or off depending on OG clusters availability
+ (#303)
 ### Removed
+- Unused `selectedStateAvailability` variable (#303)
+- Unused `statesAvailability` variable (#303)
 
 
 ## [1.0.0] 2020-04-27

--- a/README.md
+++ b/README.md
@@ -15,3 +15,11 @@ Start the app with
 ```
 python3 index.py
 ```
+
+## Notes to future code-developers
+
+The UI specifies two types of clusters : "Identified settlements by satellite imagery" and
+ "Remotely mapped settlements". In the code those are referred to as `cluster_all` or `cluster_type
+ ='all'` and `cluster_og` or `cluster_type
+ ='og'`, respectively. The reason behind this name discrepancy is that the names changed long
+  after the code was written.

--- a/app/static/js/layers.js
+++ b/app/static/js/layers.js
@@ -104,8 +104,6 @@ function highlight_state(feature, layer) {
     // Update the name of the selected state only if different from the currently selected
     if (selectedState != feature.properties["name"]) {
       prevState = selectedState;
-      //update availability of state for display in side menu
-      selectedStateAvailability = feature.properties.availability;
       //update the selected state
       selectedState = feature.properties["name"];
       // Update the dropdown menu for state selection

--- a/app/static/js/sidebar.js
+++ b/app/static/js/sidebar.js
@@ -768,7 +768,7 @@ function heatmap_cb_fun(trigger=null) {
   }
 }
 
-// Triggered by the checkbox Medium Voltage Grid
+// Triggered by the checkbox Medium Voltage Grid on national level only
 function nationalGrid_cb_fun() {
   var checkBox = document.getElementById("nationalGridCheckbox");
   if (checkBox.checked == true) {
@@ -826,6 +826,13 @@ function download_clusters_fun() {
   export_csv_link.click()
 }
 
+/*
+Triggered by the checkbox Identified settlements by satellite imagery on state level only
+
+Parameters
+----------
+    :trigger: str, can be one of ('user', 'map-click', 'zoom', 'random-cluster', 'init', 'button')
+*/
 function clusters_cb_fun(trigger=null) {
   var filter_icon = document.getElementById("clusters_filter");
 
@@ -878,6 +885,13 @@ function clusters_cb_fun(trigger=null) {
   */
 }
 
+/*
+Triggered by the checkbox Remotely mapped settlements on state level only
+
+Parameters
+----------
+    :trigger: str, can be one of ('user', 'map-click', 'zoom', 'random-cluster', 'init', 'button')
+*/
 function ogClusters_cb_fun(trigger=null) {
   var filter_icon = document.getElementById("ogClusters_filter");
 

--- a/app/static/js/sidebar.js
+++ b/app/static/js/sidebar.js
@@ -492,10 +492,15 @@ function adapt_sidebar_to_selection_level(selectionLevel) {
     document.getElementById("village").className = "cell small-6 level sidebar__btn inert disabled";
   }
 
-  if (ogClustersAvailability == false) {
+  if (selectionLevel == "national") {
     document.getElementById("ogClustersTopLevelPanel").className = disable_sidebar__btn(document.getElementById("ogClustersTopLevelPanel").className);
-  } else {
-    document.getElementById("ogClustersTopLevelPanel").className = enable_sidebar__btn(document.getElementById("ogClustersTopLevelPanel").className);
+  }
+  else {
+      if (ogClustersAvailability == false) {
+        document.getElementById("ogClustersTopLevelPanel").className = disable_sidebar__btn(document.getElementById("ogClustersTopLevelPanel").className);
+      } else {
+        document.getElementById("ogClustersTopLevelPanel").className = enable_sidebar__btn(document.getElementById("ogClustersTopLevelPanel").className);
+      }
   }
 
   document.getElementById(selectionLevel).className = "cell small-6 level sidebar__btn active";

--- a/app/static/js/sidebar.js
+++ b/app/static/js/sidebar.js
@@ -12,7 +12,6 @@ var level = "national";
 var previous_level = level;
 var statesList = ["Abia", "Adamawa", "Akwa Ibom", "Anambra", "Bauchi", "Bayelsa", "Benue", "Borno", "Cross River", "Delta", "Ebonyi", "Edo", "Ekiti", "Enugu", "Federal Capital Territory", "Gombe", "Imo", "Jigawa", "Kaduna", "Kano", "Katsina", "Kebbi", "Kogi", "Kwara", "Lagos", "Nasarawa", "Niger", "Ogun", "Ondo", "Osun", "Oyo", "Plateau", "Rivers", "Sokoto", "Taraba", "Yobe", "Zamfara"];
 var selectedState = "init";
-var selectedStateAvailability = 0;
 var prevState = selectedState;
 var selectedStateOptions = {bounds: null};
 var filteredClusters = 0;
@@ -28,20 +27,8 @@ var current_cluster_centroids = Object();
 var currently_featured_centroid_id = 0;
 var currently_flying_to_cluster = false;
 var downloadingClusters = false;
-var statesWithOgClusters = [
-    'Jigawa',
-     'Kano',
-     'Katsina',
-     'Sokoto',
-     'Kebbi',
-     'Nasarawa',
-     'Edo',
-     'Osun',
-     'Enugu',
-     'Kogi',
-     'Kwara'
-];
-
+var statesWithOgClusters = [];
+var ogClustersAvailability = false;
 var currentfilter = {
   minarea: 0.1,
   maxarea: 10,
@@ -134,11 +121,6 @@ var OGClusterLayers = {
   "Taraba": "",
   "Yobe": "nesp2_state_offgrid_clusters_yobe",
   "Zamfara": "nesp2_state_offgrid_clusters_zamfara",
-}
-// define dictionary with availability status of states
-var statesAvailability = {};
-for(const key of Object.keys(nigeria_states_simplified.features)){
-  statesAvailability[nigeria_states_simplified.features[key].properties.name] = nigeria_states_simplified.features[key].properties.availability;
 }
 
 // fetch info about states which have og_clusters
@@ -510,8 +492,10 @@ function adapt_sidebar_to_selection_level(selectionLevel) {
     document.getElementById("village").className = "cell small-6 level sidebar__btn inert disabled";
   }
 
-  if (selectionLevel == "state" && selectedStateAvailability % 4 < 2) {
+  if (ogClustersAvailability == false) {
     document.getElementById("ogClustersTopLevelPanel").className = disable_sidebar__btn(document.getElementById("ogClustersTopLevelPanel").className);
+  } else {
+    document.getElementById("ogClustersTopLevelPanel").className = enable_sidebar__btn(document.getElementById("ogClustersTopLevelPanel").className);
   }
 
   document.getElementById(selectionLevel).className = "cell small-6 level sidebar__btn active";
@@ -601,7 +585,7 @@ function adapt_view_to_state_level() {
   if (previous_level == "national" && prevState == "init") {
 
       // In States where there is no Grid, All Clusters should be shown instead of mapped village clusters
-      if (statesAvailability[selectedState] / 4 < 1) {
+      if (ogClustersAvailability == false) {
         set_clusters_toggle(true);
       }
       else {
@@ -650,8 +634,7 @@ function national_button_fun(trigger="button") {
 function state_button_fun(trigger="button") {
   previous_level = level;
   level = "state";
-  selectedStateAvailability = statesAvailability[selectedState];
-  adapt_sidebar_to_selection_level(level);
+
   // click on the state level button from national level
   if (previous_level == "national" && trigger == "button"){
       // select a random state which has off-grid clusters
@@ -659,6 +642,11 @@ function state_button_fun(trigger="button") {
       // Update the states menu list
       document.getElementById("stateSelect").value = selectedState;
   };
+
+  // check if the og clusters are available
+  ogClustersAvailability = statesWithOgClusters.includes(selectedState)
+  //selectedStateAvailability = statesAvailability[selectedState];
+  adapt_sidebar_to_selection_level(level);
 
   // updates the bounds of the selected state's layer
   updateSelectedStateBounds()

--- a/app/static/js/sidebar.js
+++ b/app/static/js/sidebar.js
@@ -741,12 +741,26 @@ function state_dropdown_fun() {
   }
 };
 
-// Triggered by the checkbox Populated Areas
-function heatmap_cb_fun() {
+/*
+Triggered by the checkbox Identified settlements by satellite imagery on national level only
+
+Parameters
+----------
+    :trigger: str, can be one of ('user', 'map-click', 'zoom', 'random-cluster', 'init', 'button')
+*/
+function heatmap_cb_fun(trigger=null) {
   var checkBox = document.getElementById("heatmapCheckbox");
   if (checkBox.checked == true) {
     document.getElementById("heatmapPanel").style.borderLeft = '.25rem solid #1DD069';
     add_layer(national_heatmap);
+    if (trigger == "user") {
+        //activate all clusters
+        set_clusters_toggle(true);
+        // deactivate og clusters
+        set_og_clusters_toggle(false);
+        clusters_cb_fun();
+        ogClusters_cb_fun();
+  }
   } else {
     document.getElementById("heatmapPanel").style.borderLeft = '.25rem solid #eeeff1';
     remove_layer(national_heatmap);

--- a/app/static/js/sidebar.js
+++ b/app/static/js/sidebar.js
@@ -876,49 +876,6 @@ function clusters_cb_fun(trigger=null) {
   */
 }
 
-function template_filter_fun(id) {
-  var newFilter = document.getElementsByName(id + "Content");
-  var checkBox = document.getElementById(id + "Checkbox");
-  if (checkBox.checked == true) {
-    var i;
-    for (i = 0; i < newFilter.length; i++) {
-      newFilter[i].className = toggle_sidebar_filter(newFilter[i].className)
-    }
-
-    var prevFilter = document.querySelectorAll(".content-filter");
-    var j;
-    for (j = 0; j < prevFilter.length; j++) {
-
-      if (prevFilter[j].attributes.name.value !== id + "Content") {
-        prevFilter[j].className = disable_sidebar_filter(prevFilter[j].className);
-      }
-    }
-    if (id == "clusters") {
-        map.fireEvent("filterchange", currentfilter);
-        update_filter();
-    }
-    else{
-        map.fireEvent("ogfilterchange", currentfilter);
-        update_filter();
-    }
-  } else {
-    var prevFilter = document.querySelectorAll(".content-filter");
-    var j;
-    for (j = 0; j < prevFilter.length; j++) {
-
-      if (prevFilter[j].attributes.name.value === id + "Content") {
-        prevFilter[j].className = disable_sidebar_filter(prevFilter[j].className);
-      }
-    }
-
-  }
-}
-
-function clusters_filter_fun() {
-  template_filter_fun("clusters");
-}
-
-
 function ogClusters_cb_fun(trigger=null) {
   var filter_icon = document.getElementById("ogClusters_filter");
 
@@ -961,9 +918,51 @@ function ogClusters_cb_fun(trigger=null) {
   }
 }
 
+function template_filter_fun(id) {
+  var newFilter = document.getElementsByName(id + "Content");
+  var checkBox = document.getElementById(id + "Checkbox");
+  if (checkBox.checked == true) {
+    var i;
+    for (i = 0; i < newFilter.length; i++) {
+      newFilter[i].className = toggle_sidebar_filter(newFilter[i].className)
+    }
+
+    var prevFilter = document.querySelectorAll(".content-filter");
+    var j;
+    for (j = 0; j < prevFilter.length; j++) {
+
+      if (prevFilter[j].attributes.name.value !== id + "Content") {
+        prevFilter[j].className = disable_sidebar_filter(prevFilter[j].className);
+      }
+    }
+    if (id == "clusters") {
+        map.fireEvent("filterchange", currentfilter);
+        update_filter();
+    }
+    else{
+        map.fireEvent("ogfilterchange", currentfilter);
+        update_filter();
+    }
+  } else {
+    var prevFilter = document.querySelectorAll(".content-filter");
+    var j;
+    for (j = 0; j < prevFilter.length; j++) {
+
+      if (prevFilter[j].attributes.name.value === id + "Content") {
+        prevFilter[j].className = disable_sidebar_filter(prevFilter[j].className);
+      }
+    }
+
+  }
+}
+
+function clusters_filter_fun() {
+  template_filter_fun("clusters");
+}
 function ogClusters_filter_fun() {
   template_filter_fun("ogClusters");
 }
+
 
 
 // Triggered by the checkbox Grid

--- a/app/static/js/sidebar.js
+++ b/app/static/js/sidebar.js
@@ -586,18 +586,20 @@ function adapt_view_to_state_level() {
   if(previous_level == "national") {
     document.getElementById("gridCheckbox").checked = document.getElementById("nationalGridCheckbox").checked ;
   }
-  // Apply only when choosing state right after landing, otherwise keep user options
-  if (previous_level == "national" && prevState == "init") {
 
-      // In States where there is no Grid, All Clusters should be shown instead of mapped village clusters
-      if (ogClustersAvailability == false) {
-        set_clusters_toggle(true);
-      }
-      else {
+  // In States where there is no Grid, All Clusters should be shown instead of mapped village clusters
+  if (ogClustersAvailability == false) {
+    set_clusters_toggle(true);
+  }
+  else {
+    // Choose remotely mapped settlements only when choosing state right after landing, otherwise
+    // keep user options
+    if (prevState == "init") {
         // Load the remotely mapped villages clusters
         set_og_clusters_toggle(true);
-      }
+    }
   }
+
   clusters_cb_fun();
   ogClusters_cb_fun();
 
@@ -650,7 +652,6 @@ function state_button_fun(trigger="button") {
 
   // check if the og clusters are available
   ogClustersAvailability = statesWithOgClusters.includes(selectedState)
-  //selectedStateAvailability = statesAvailability[selectedState];
   adapt_sidebar_to_selection_level(level);
 
   // updates the bounds of the selected state's layer

--- a/app/static/js/sidebar.js
+++ b/app/static/js/sidebar.js
@@ -598,6 +598,12 @@ function adapt_view_to_state_level() {
         // Load the remotely mapped villages clusters
         set_og_clusters_toggle(true);
     }
+    else {
+        if (document.getElementById("clustersCheckbox").checked == true) {
+            // Load the remotely mapped villages clusters
+            set_og_clusters_toggle(true);
+        }
+    }
   }
 
   clusters_cb_fun();
@@ -771,6 +777,12 @@ function heatmap_cb_fun(trigger=null) {
     document.getElementById("heatmapPanel").style.borderLeft = '.25rem solid #eeeff1';
     remove_layer(national_heatmap);
     national_heatmap.bringToFront();
+    if (trigger == "user") {
+        //deactivate all clusters
+        set_clusters_toggle(false);
+        clusters_cb_fun();
+        ogClusters_cb_fun();
+  }
   }
 }
 


### PR DESCRIPTION
Fix #302 

At landing (after hitting refresh) if the user selects a state:
The state should display the RMS (og clusters) if they are available (i.e. if a survey was conducted <--> `cluster_offgrid` column of `se4all.boundary_adm1_status` table in database is set to `true`) and switch the RMS toggle to true. If there are not available, the ISSM toggle is set to true and the RMS toggle is disabled.

From national level if the user plays with the national ISSI toggle (the RMS toggle is greyed out on national level):
- if previously the RMS was on, it will be switched off if the ISSI is switched on
- if ISSI toggle is set to true, then it will be remembered if the user selects a state and the ISSI will be shown
- if ISSI toggle is set to false, then both RMS and ISSI are set to false and if the user selects a state RMS will be chosen over ISSI provided they are available, otherwise ISSI will be shown