### PR TITLE
Fix attribution for webmap layers

### DIFF
--- a/app/static/js/layers.js
+++ b/app/static/js/layers.js
@@ -20,13 +20,13 @@ var esri = L.tileLayer("https://server.arcgisonline.com/ArcGIS/rest/services/Wor
 // Basic png-tile taken from wmflabs
 var osm_gray = L.tileLayer("https://tiles.wmflabs.org/bw-mapnik/{z}/{x}/{y}.png", {
   maxZoom: 19,
-  attribution: '&copy; Tiles style from OpenStreetMap, hosted by wmflabs. <a href="https://wmflabs.org"></a>'
+  attribution: 'Gray tiles &copy OpenStreetMap, hosted by <a href="https://wmflabs.org">wmflabs</a>.'
 });
 
 // Basic png-tile layer for background taken from tile server serves zoom levels 5-9
 var national_background = L.tileLayer(tileserver + "nesp2_national_background/{z}/{x}/{y}.png", {
   maxZoom: 19,
-  attribution: '☮'
+  attribution: 'National tiles <a href="http://se4allwebpage.westeurope.cloudapp.azure.com/about-map"> &copy se4all</a>'
 });
 
 // Basic png-tile layer for overlays taken from tile server serves zoom levels 5-9

--- a/app/static/js/layers.js
+++ b/app/static/js/layers.js
@@ -1,3 +1,6 @@
+const website_url = "http://se4allwebpage.westeurope.cloudapp.azure.com";
+
+
 // Basic png-tile layer taken from OpenStreetMap
 var osm = L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
   maxZoom: 19,
@@ -26,7 +29,7 @@ var osm_gray = L.tileLayer("https://tiles.wmflabs.org/bw-mapnik/{z}/{x}/{y}.png"
 // Basic png-tile layer for background taken from tile server serves zoom levels 5-9
 var national_background = L.tileLayer(tileserver + "nesp2_national_background/{z}/{x}/{y}.png", {
   maxZoom: 19,
-  attribution: 'National tiles <a href="http://se4allwebpage.westeurope.cloudapp.azure.com/about-map"> &copy se4all</a>'
+  attribution: 'National tiles <a href="' + website_url +  '/about-map"> &copy se4all</a>'
 });
 
 // Basic png-tile layer for overlays taken from tile server serves zoom levels 5-9


### PR DESCRIPTION
Closes #307 

@yelsre this removes the ☮ sign and adds attribution to se4all with the link to the about map page.

the sources now read:
* For the tiles created for the national view: National tiles <a href="http://se4allwebpage.westeurope.cloudapp.azure.com/about-map"> © se4all</a>
* For the gray osm tiles: Gray tiles © OpenStreetMap, hosted by <a href="https://wmflabs.org">wmflabs</a>.

They only show when the layer is loaded in the map (the osm tiles are in the national view as well, because it makes for a somewhat smoother transition to state level, but they are covered by the other tiles). 

Let me know if you approve of this solution or i should rephrase something. If you have no changes to suggest, I will merge this.