### PR TITLE
Remove state grid at initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,12 @@ Here is a template for new release sections
 ### Changed
 - Cluster toggles in sidebar automatically switch on or off depending on OG clusters availability
  (#303)
+- Rename `gridCheckbox` to `stateGridCheckbox (#312)
+- Rename `grid_layer` to `state_grid_layer (#312)
 ### Removed
 - Unused `selectedStateAvailability` variable (#303)
 - Unused `statesAvailability` variable (#303)
+- Javascript code in `index.html` to initialize state_grid and state_level toggles (#312)
 
 
 ## [1.0.0] 2020-04-27

--- a/app/static/js/layers.js
+++ b/app/static/js/layers.js
@@ -172,12 +172,12 @@ function zoomToSelectedState() {
     map.flyToBounds(selectedStateOptions.bounds, {maxZoom: 19});
 };
 
-// Definitions and functions for the grid_layer
+// Definitions and functions for the state_grid_layer
 
 // Vector tiles layer that is adapted (URL) depending on the chosen state. Contains layers '11kV' and '33kV' Columns: several, but of no interest to the map
 
 //Always Using the entire Grid
-var grid_layer = L.vectorGrid.protobuf(tileserver + "nesp2_state_grid/{z}/{x}/{y}.pbf", {
+var state_grid_layer = L.vectorGrid.protobuf(tileserver + "nesp2_state_grid/{z}/{x}/{y}.pbf", {
   rendererFactory: L.canvas.tile,
   vectorTileLayerStyles: {
     '33_kV': function(prop, zoom) {
@@ -205,14 +205,6 @@ function redefine_grid_layer() {
       },
     }
   });
-};
-
-// Update the state level grid layer with tiles
-function update_grid_layer() {
-  //remove_layer(grid_layer);
-  //redefine_grid_layer();
-  // Add the grid layer depending on grid checkbox value
-  grid_cb_fun();
 };
 
 // Adds functions for filters and styling to a defined input grid-cluster-Layer

--- a/app/static/js/layers.js
+++ b/app/static/js/layers.js
@@ -189,24 +189,6 @@ var state_grid_layer = L.vectorGrid.protobuf(tileserver + "nesp2_state_grid/{z}/
   }
 });
 
-// Assign the selected state grid tile to the grid_layer
-function redefine_grid_layer() {
-// Vector tiles layer that is adapted (URL) depending on the chosen state. Contains layers '11kV' and '33kV' Columns: several, but of no interest to the map
-
-//Always Using the entire Grid
-  grid_layer = L.vectorGrid.protobuf(tileserver + "nesp2_state_grid/{z}/{x}/{y}.pbf", {
-    rendererFactory: L.canvas.tile,
-    vectorTileLayerStyles: {
-      '33_kV': function(prop, zoom) {
-        return gridStyle33kv
-      },
-      '11_kV': function(prop, zoom) {
-        return gridStyle11kv
-      },
-    }
-  });
-};
-
 // Adds functions for filters and styling to a defined input grid-cluster-Layer
 function addFunctionsToClusterLayer(layer) {
   layer.on("click", function(e) {

--- a/app/static/js/layers.js
+++ b/app/static/js/layers.js
@@ -53,15 +53,27 @@ var welcome_view = L.tileLayer(tileserver + "nesp2_national_welcome-view/{z}/{x}
 var centroidsGroup = L.layerGroup().addTo(map);
 
 
-function remove_layer(layer) {
+function remove_layer(layer, msg=null) {
   if (map.hasLayer(layer) == true) {
     map.removeLayer(layer);
   }
+  else{
+    if (msg != null){
+        console.log("Cannot remove unexisting layer");
+        console.log(msg);
+    }
+  }
 };
 
-function add_layer(layer) {
+function add_layer(layer, msg=null) {
   if (map.hasLayer(layer) == false) {
     map.addLayer(layer);
+  }
+  else{
+    if (msg != null){
+        console.log("Cannot add already existing layer");
+        console.log(msg);
+    }
   }
 };
 

--- a/app/static/js/map.js
+++ b/app/static/js/map.js
@@ -1,5 +1,5 @@
-map.addLayer(national_background);
-map.addLayer(osm_gray);
+add_layer(national_background);
+add_layer(osm_gray);
 
 // legend located at the lower right for datasets on national level
 var legend = L.control({

--- a/app/static/js/sidebar.js
+++ b/app/static/js/sidebar.js
@@ -527,11 +527,11 @@ function adapt_view_to_national_level() {
     document.getElementById("nationalGridCheckbox").checked = true;
     set_clusters_toggle(false);
     set_og_clusters_toggle(false);
-    document.getElementById("gridCheckbox").checked = false;
+    document.getElementById("stateGridCheckbox").checked = false;
   }
   if (previous_level == "state" || previous_level == "village") {
     document.getElementById("heatmapCheckbox").checked = document.getElementById("clustersCheckbox").checked;
-    document.getElementById("nationalGridCheckbox").checked = document.getElementById("gridCheckbox").checked;
+    document.getElementById("nationalGridCheckbox").checked = document.getElementById("stateGridCheckbox").checked;
   }
   // load the populated areas
   heatmap_cb_fun();
@@ -584,7 +584,7 @@ function adapt_view_to_state_level() {
   states_cb_fun();
 
   if(previous_level == "national") {
-    document.getElementById("gridCheckbox").checked = document.getElementById("nationalGridCheckbox").checked ;
+    document.getElementById("stateGridCheckbox").checked = document.getElementById("nationalGridCheckbox").checked ;
   }
 
   // In States where there is no Grid, All Clusters should be shown instead of mapped village clusters
@@ -1000,8 +1000,8 @@ function ogClusters_filter_fun() {
 
 
 // Triggered by the checkbox Grid
-function grid_cb_fun() {
-  var checkBox = document.getElementById("gridCheckbox");
+function stateGrid_cb_fun() {
+  var checkBox = document.getElementById("stateGridCheckbox");
   if (checkBox.checked == true) {
     document.getElementById("gridPanel").style.borderLeft = '.25rem solid #1DD069';
     add_layer(grid_layer);

--- a/app/static/js/sidebar.js
+++ b/app/static/js/sidebar.js
@@ -554,8 +554,8 @@ function adapt_view_to_national_level() {
 
   remove_basemaps();
 
-  map.addLayer(osm_gray);
-  map.addLayer(national_background);
+  add_layer(osm_gray);
+  add_layer(national_background);
 
   // reactive fitting of Nigeria on the map
   map.fitBounds(L.latLngBounds(L.latLng(14, 15), L.latLng(4, 2.5)))

--- a/app/static/js/sidebar.js
+++ b/app/static/js/sidebar.js
@@ -147,7 +147,7 @@ function set_filtered_centroids_keys(value) {
     browse_centroids_keys = value;
 }
 
-function give_status(context=null, display=false) {
+function give_status(context=null, display=true) {
     if (display == true) {
         console.log("Status on");
         if (context) {
@@ -557,9 +557,6 @@ function adapt_view_to_national_level() {
   map.addLayer(osm_gray);
   map.addLayer(national_background);
 
-  // Linked to the checkbox Grid
-  remove_layer(grid_layer);
-
   // reactive fitting of Nigeria on the map
   map.fitBounds(L.latLngBounds(L.latLng(14, 15), L.latLng(4, 2.5)))
   // if the fitBound has smaller zoom level, update the min zoom level
@@ -567,6 +564,10 @@ function adapt_view_to_national_level() {
 
   // update the info box on the top left
   update_infoBox()
+
+  // Linked to the checkbox Grid
+  remove_layer(state_grid_layer,msg="state_layer");
+
 
 };
 

--- a/app/static/js/sidebar.js
+++ b/app/static/js/sidebar.js
@@ -147,7 +147,7 @@ function set_filtered_centroids_keys(value) {
     browse_centroids_keys = value;
 }
 
-function give_status(context=null, display=true) {
+function give_status(context=null, display=false) {
     if (display == true) {
         console.log("Status on");
         if (context) {
@@ -566,7 +566,7 @@ function adapt_view_to_national_level() {
   update_infoBox()
 
   // Linked to the checkbox Grid
-  remove_layer(state_grid_layer,msg="state_layer");
+  remove_layer(state_grid_layer);
 
 
 };

--- a/app/static/js/sidebar.js
+++ b/app/static/js/sidebar.js
@@ -1004,10 +1004,10 @@ function ogClusters_filter_fun() {
 function stateGrid_cb_fun() {
   var checkBox = document.getElementById("stateGridCheckbox");
   if (checkBox.checked == true) {
-    document.getElementById("gridPanel").style.borderLeft = '.25rem solid #1DD069';
+    document.getElementById("stateGridPanel").style.borderLeft = '.25rem solid #1DD069';
     add_layer(state_grid_layer);
   } else {
-    document.getElementById("gridPanel").style.borderLeft = '.25rem solid #eeeff1';
+    document.getElementById("stateGridPanel").style.borderLeft = '.25rem solid #eeeff1';
     remove_layer(state_grid_layer);
   }
 

--- a/app/static/js/sidebar.js
+++ b/app/static/js/sidebar.js
@@ -535,8 +535,9 @@ function adapt_view_to_national_level() {
   }
   // load the populated areas
   heatmap_cb_fun();
-  // load the medium voltage grid
+  // load the medium voltage grid on national level and untick the one on the state level
   nationalGrid_cb_fun();
+  stateGrid_cb_fun();
 
   // Remotely mapped villages layer
   remove_layer(clusterLayer[selectedState]);
@@ -609,9 +610,8 @@ function adapt_view_to_state_level() {
   clusters_cb_fun();
   ogClusters_cb_fun();
 
-
   add_layer(nigeria_states_borders_geojson);
-  update_grid_layer();
+
   add_layer(osm_gray);
 
   // remove the medium voltage grid
@@ -619,6 +619,7 @@ function adapt_view_to_state_level() {
   heatmap_cb_fun();
   // remove the populated areas
   document.getElementById("nationalGridCheckbox").checked = false;
+  stateGrid_cb_fun();
   nationalGrid_cb_fun();
 
   remove_layer(hot);
@@ -1004,10 +1005,10 @@ function stateGrid_cb_fun() {
   var checkBox = document.getElementById("stateGridCheckbox");
   if (checkBox.checked == true) {
     document.getElementById("gridPanel").style.borderLeft = '.25rem solid #1DD069';
-    add_layer(grid_layer);
+    add_layer(state_grid_layer);
   } else {
     document.getElementById("gridPanel").style.borderLeft = '.25rem solid #eeeff1';
-    remove_layer(grid_layer);
+    remove_layer(state_grid_layer);
   }
 
   /*$.get({url: $SCRIPT_ROOT,

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -133,7 +133,7 @@
         <!-- grid layer on national level only -->
         {{ checkbox.input(id="nationalGrid", label="Medium voltage grid", visible={'national': 'show'}, help_icon=True, help_link="ongridmapping") }}
         <!-- grid layer on state and village level only -->
-        {{ checkbox.input(id="grid", label="Medium voltage grid", visible={'state': 'show', 'village': 'show'}, help_icon=True, help_link="ongridmapping") }}
+        {{ checkbox.input(id="stateGrid", label="Medium voltage grid", visible={'state': 'show', 'village': 'show'}, help_icon=True, help_link="ongridmapping") }}
 
         {{ checkbox.input(id="heatmap", label="Identified settlements by satellite imagery", visible={'national': 'show'}, help_icon=True, help_link="clusteridentification") }}
 
@@ -238,7 +238,7 @@
           stateCheckBox.click()
       }
 
-      var gCheckBox = document.getElementById("gridCheckbox")
+      var gCheckBox = document.getElementById("stateGridCheckbox")
       {% if grid_content is defined %}
           var grid_content = {{ grid_content|safe }};
       {% else %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -228,26 +228,6 @@
     <script src="{{ url_for('static', filename='js/map.js') }}"></script>
     <script type=text/javascript>
 
-      var stateCheckBox = document.getElementById("statesCheckbox")
-      {% if states_content is defined %}
-          var states_content = {{ states_content|safe }};
-      {% else %}
-          var states_content=false;
-      {% endif %}
-      if (states_content != stateCheckBox.checked){
-          stateCheckBox.click()
-      }
-
-      var gCheckBox = document.getElementById("stateGridCheckbox")
-      {% if grid_content is defined %}
-          var grid_content = {{ grid_content|safe }};
-      {% else %}
-          var grid_content=false;
-      {% endif %}
-
-      if (grid_content != gCheckBox.checked){
-          gCheckBox.click()
-      }
   $(document).ready(function(){
       $(document).foundation();
       $('.filter_icon').on("mouseenter", function(){


### PR DESCRIPTION
- Rename variable with more explicit names
- Fix #296, state grid wrongfully displayed on inital national level state 