### PR TITLE
Fix filter icon highlight

### DIFF
--- a/app/static/js/sidebar.js
+++ b/app/static/js/sidebar.js
@@ -964,15 +964,6 @@ function template_filter_fun(id) {
   var newFilter = document.getElementsByName(id + "Content");
   var checkBox = document.getElementById(id + "Checkbox");
   if (checkBox.checked == true) {
-    // reset the current filter id
-    if (currentfilter["filterID"] == ""){
-        // if currentfilter id is empty, then it means that the filter will be expanded
-        currentfilter["filterID"] = id;
-    }
-    else if (currentfilter["filterID"] == id){
-        // if currentfilter id is the same as id, then the filter will be hidden
-        currentfilter["filterID"] = "";
-    }
 
     var i;
     for (i = 0; i < newFilter.length; i++) {
@@ -997,8 +988,6 @@ function template_filter_fun(id) {
         update_filter();
     }
   } else {
-    // reset the current filter to default
-    currentfilter["filterID"] = "";
     var prevFilter = document.querySelectorAll(".content-filter");
     var j;
     for (j = 0; j < prevFilter.length; j++) {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -266,18 +266,6 @@
 
   $(document).ready(function(){
       $(document).foundation();
-      $('.filter_icon').on("mouseenter", function(){
-          // Change src attribute of image
-          $(this).attr("src", "../static/img/icons/i_funnel_dark_gray.svg");
-
-      });
-      $('.filter_icon').on("mouseleave", function(){
-          // Change src attribute of image if the filter is not selected
-          var filter_section = $(this).attr("id").split('_')[0];
-          if (currentfilter["filterID"] != filter_section) {
-            $(this).attr("src", "../static/img/icons/i_funnel_gray.svg");
-          }
-      });
 
       //display a warning for small screens
       if($(window).width() < screen_width_threshold) {

--- a/app/templates/sidebar_checkbox.html
+++ b/app/templates/sidebar_checkbox.html
@@ -17,7 +17,7 @@
             <img
                     id="{{ id }}_filter"
                     class="filter_icon"
-                    src="{{ url_for('static', filename='img/icons/i_funnel_gray.svg') }}"
+                    src="{{ url_for('static', filename='img/icons/i_funnel_dark_gray.svg') }}"
                     onclick="{{ id }}_filter_fun()"
                     title="Click on the funnel to expand filters"
             >


### PR DESCRIPTION
The color of the filter icon (funnel) is now:

- light grey (when the button/toggle on the right is not green - because the light grey matches the button/toggle color then)
- dark grey (when the button/toggle on the right is green)
